### PR TITLE
feat: implement comprehensive MQTT retained message functionality

### DIFF
--- a/pkg/retainer/retainer.go
+++ b/pkg/retainer/retainer.go
@@ -1,0 +1,330 @@
+// Copyright 2023 The emqx-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package retainer provides MQTT retained message functionality
+// inspired by EMQX's retainer implementation.
+package retainer
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/turtacn/emqx-go/pkg/storage/messages"
+)
+
+// RetainedMessage represents a stored retained message
+type RetainedMessage struct {
+	Topic      string            `json:"topic"`
+	Payload    []byte            `json:"payload"`
+	QoS        byte              `json:"qos"`
+	Timestamp  time.Time         `json:"timestamp"`
+	ExpiryTime *time.Time        `json:"expiry_time,omitempty"`
+	ClientID   string            `json:"client_id,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
+}
+
+// Config defines retainer configuration
+type Config struct {
+	// Message retention time, 0 means no expiry
+	MessageExpiryInterval time.Duration `yaml:"message_expiry_interval" json:"message_expiry_interval"`
+
+	// Maximum message size allowed
+	MaxPayloadSize int64 `yaml:"max_payload_size" json:"max_payload_size"`
+
+	// Whether to stop publishing clear messages (empty payload with retain=true)
+	StopPublishClearMsg bool `yaml:"stop_publish_clear_msg" json:"stop_publish_clear_msg"`
+
+	// Maximum number of retained messages
+	MaxRetainedMessages uint64 `yaml:"max_retained_messages" json:"max_retained_messages"`
+
+	// Cleanup interval for expired messages
+	CleanupInterval time.Duration `yaml:"cleanup_interval" json:"cleanup_interval"`
+}
+
+// DefaultConfig returns a default retainer configuration
+func DefaultConfig() *Config {
+	return &Config{
+		MessageExpiryInterval: 0, // No expiry by default
+		MaxPayloadSize:        1024 * 1024, // 1MB
+		StopPublishClearMsg:   false,
+		MaxRetainedMessages:   10000,
+		CleanupInterval:       5 * time.Minute,
+	}
+}
+
+// Retainer manages retained messages
+type Retainer struct {
+	storage messages.StorageBackend
+	config  *Config
+	mu      sync.RWMutex
+
+	// Cleanup management
+	cleanupTicker *time.Ticker
+	stopCleanup   chan struct{}
+}
+
+// New creates a new retainer instance
+func New(storage messages.StorageBackend, config *Config) *Retainer {
+	if config == nil {
+		config = DefaultConfig()
+	}
+
+	r := &Retainer{
+		storage:     storage,
+		config:      config,
+		stopCleanup: make(chan struct{}),
+	}
+
+	// Start cleanup routine if expiry is enabled
+	if config.CleanupInterval > 0 {
+		r.startCleanupRoutine()
+	}
+
+	return r
+}
+
+// StoreRetained stores a retained message
+func (r *Retainer) StoreRetained(ctx context.Context, topic string, payload []byte, qos byte, clientID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Check payload size limit
+	if r.config.MaxPayloadSize > 0 && int64(len(payload)) > r.config.MaxPayloadSize {
+		return fmt.Errorf("payload size %d exceeds maximum %d", len(payload), r.config.MaxPayloadSize)
+	}
+
+	// Empty payload means delete retained message
+	if len(payload) == 0 {
+		log.Printf("[INFO] Deleting retained message for topic: %s", topic)
+		return r.storage.DeleteRetained(ctx, topic)
+	}
+
+	// Check max retained messages limit
+	if r.config.MaxRetainedMessages > 0 {
+		stats := r.storage.Stats()
+		if stats.RetainedMessages >= r.config.MaxRetainedMessages {
+			return fmt.Errorf("maximum retained messages limit (%d) reached", r.config.MaxRetainedMessages)
+		}
+	}
+
+	// Create retained message
+	msg := messages.Message{
+		ID:        generateMessageID(),
+		Topic:     topic,
+		Payload:   payload,
+		QoS:       qos,
+		Retained:  true,
+		Timestamp: time.Now(),
+		ClientID:  clientID,
+	}
+
+	// Set expiry time if configured
+	if r.config.MessageExpiryInterval > 0 {
+		expiryTime := msg.Timestamp.Add(r.config.MessageExpiryInterval)
+		msg.ExpiryTime = &expiryTime
+	}
+
+	log.Printf("[INFO] Storing retained message for topic: %s, payload size: %d", topic, len(payload))
+	return r.storage.StoreRetained(ctx, topic, msg)
+}
+
+// GetRetainedMessages retrieves retained messages matching the topic filter
+func (r *Retainer) GetRetainedMessages(ctx context.Context, topicFilter string) ([]RetainedMessage, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	msgs, err := r.storage.GetRetained(ctx, topicFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]RetainedMessage, 0, len(msgs))
+	now := time.Now()
+
+	for _, msg := range msgs {
+		// Skip expired messages
+		if msg.ExpiryTime != nil && now.After(*msg.ExpiryTime) {
+			continue
+		}
+
+		retainedMsg := RetainedMessage{
+			Topic:      msg.Topic,
+			Payload:    msg.Payload,
+			QoS:        msg.QoS,
+			Timestamp:  msg.Timestamp,
+			ExpiryTime: msg.ExpiryTime,
+			ClientID:   msg.ClientID,
+			Headers:    msg.Headers,
+		}
+		result = append(result, retainedMsg)
+	}
+
+	log.Printf("[DEBUG] Retrieved %d retained messages for filter: %s", len(result), topicFilter)
+	return result, nil
+}
+
+// DeleteRetained removes a retained message
+func (r *Retainer) DeleteRetained(ctx context.Context, topic string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	log.Printf("[INFO] Deleting retained message for topic: %s", topic)
+	return r.storage.DeleteRetained(ctx, topic)
+}
+
+// GetStats returns retainer statistics
+func (r *Retainer) GetStats() RetainerStats {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	storageStats := r.storage.Stats()
+	return RetainerStats{
+		RetainedMessages: storageStats.RetainedMessages,
+		TotalSize:        storageStats.StorageSize,
+		MaxMessages:      r.config.MaxRetainedMessages,
+		MaxPayloadSize:   r.config.MaxPayloadSize,
+		ExpiryInterval:   r.config.MessageExpiryInterval,
+	}
+}
+
+// RetainerStats provides retainer statistics
+type RetainerStats struct {
+	RetainedMessages uint64        `json:"retained_messages"`
+	TotalSize        uint64        `json:"total_size_bytes"`
+	MaxMessages      uint64        `json:"max_messages"`
+	MaxPayloadSize   int64         `json:"max_payload_size"`
+	ExpiryInterval   time.Duration `json:"expiry_interval"`
+}
+
+// Close shuts down the retainer
+func (r *Retainer) Close() error {
+	if r.cleanupTicker != nil {
+		r.cleanupTicker.Stop()
+		close(r.stopCleanup)
+	}
+	return nil
+}
+
+// startCleanupRoutine starts the background cleanup process
+func (r *Retainer) startCleanupRoutine() {
+	r.cleanupTicker = time.NewTicker(r.config.CleanupInterval)
+
+	go func() {
+		for {
+			select {
+			case <-r.cleanupTicker.C:
+				r.cleanupExpiredMessages()
+			case <-r.stopCleanup:
+				return
+			}
+		}
+	}()
+
+	log.Printf("[INFO] Started retained message cleanup routine with interval: %v", r.config.CleanupInterval)
+}
+
+// cleanupExpiredMessages removes expired retained messages
+func (r *Retainer) cleanupExpiredMessages() {
+	ctx := context.Background()
+
+	// Get all retained messages
+	msgs, err := r.storage.GetRetained(ctx, "#") // Get all topics
+	if err != nil {
+		log.Printf("[ERROR] Failed to get retained messages for cleanup: %v", err)
+		return
+	}
+
+	now := time.Now()
+	deletedCount := 0
+
+	for _, msg := range msgs {
+		if msg.ExpiryTime != nil && now.After(*msg.ExpiryTime) {
+			if err := r.storage.DeleteRetained(ctx, msg.Topic); err != nil {
+				log.Printf("[ERROR] Failed to delete expired retained message for topic %s: %v", msg.Topic, err)
+			} else {
+				deletedCount++
+			}
+		}
+	}
+
+	if deletedCount > 0 {
+		log.Printf("[INFO] Cleanup completed: deleted %d expired retained messages", deletedCount)
+	}
+}
+
+// MatchTopicFilter checks if a topic matches a topic filter
+// This implementation supports basic MQTT wildcards:
+// - # matches any topics at that level and below
+// - + matches any single topic level
+func MatchTopicFilter(topic, filter string) bool {
+	// Exact match
+	if topic == filter {
+		return true
+	}
+
+	// Multi-level wildcard - # matches everything
+	if filter == "#" {
+		return true
+	}
+
+	// Split topic and filter into levels
+	topicLevels := strings.Split(topic, "/")
+	filterLevels := strings.Split(filter, "/")
+
+	// Multi-level wildcard at the end
+	if len(filterLevels) > 0 && filterLevels[len(filterLevels)-1] == "#" {
+		// Check that all preceding levels match
+		for i := 0; i < len(filterLevels)-1; i++ {
+			if i >= len(topicLevels) {
+				return false
+			}
+			if filterLevels[i] != "+" && filterLevels[i] != topicLevels[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Both must have same number of levels for single-level wildcards
+	if len(topicLevels) != len(filterLevels) {
+		return false
+	}
+
+	// Check each level
+	for i := 0; i < len(filterLevels); i++ {
+		if filterLevels[i] == "+" {
+			// Single-level wildcard matches any single level
+			continue
+		}
+		if filterLevels[i] != topicLevels[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// generateMessageID creates a unique message identifier
+func generateMessageID() string {
+	return fmt.Sprintf("retained-%d-%d", time.Now().UnixNano(), randomInt())
+}
+
+// randomInt generates a random integer for ID generation
+func randomInt() int64 {
+	return time.Now().UnixNano() % 1000000
+}

--- a/pkg/retainer/retainer_test.go
+++ b/pkg/retainer/retainer_test.go
@@ -1,0 +1,315 @@
+// Copyright 2023 The emqx-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retainer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turtacn/emqx-go/pkg/storage/messages"
+)
+
+func createTestRetainer(t *testing.T) *Retainer {
+	config := DefaultConfig()
+	config.CleanupInterval = 100 * time.Millisecond // Faster cleanup for testing
+
+	backend, err := messages.NewMemoryBackend(messages.DefaultConfig())
+	require.NoError(t, err)
+
+	return New(backend, config)
+}
+
+func TestRetainerStoreAndGetRetained(t *testing.T) {
+	retainer := createTestRetainer(t)
+	defer retainer.Close()
+
+	ctx := context.Background()
+
+	// Test storing a retained message
+	topic := "test/retained"
+	payload := []byte("hello world")
+	qos := byte(1)
+	clientID := "test-client"
+
+	err := retainer.StoreRetained(ctx, topic, payload, qos, clientID)
+	assert.NoError(t, err)
+
+	// Test retrieving the retained message
+	messages, err := retainer.GetRetainedMessages(ctx, topic)
+	assert.NoError(t, err)
+	assert.Len(t, messages, 1)
+
+	msg := messages[0]
+	assert.Equal(t, topic, msg.Topic)
+	assert.Equal(t, payload, msg.Payload)
+	assert.Equal(t, qos, msg.QoS)
+	assert.Equal(t, clientID, msg.ClientID)
+	assert.False(t, msg.Timestamp.IsZero())
+}
+
+func TestRetainerDeleteRetained(t *testing.T) {
+	retainer := createTestRetainer(t)
+	defer retainer.Close()
+
+	ctx := context.Background()
+	topic := "test/delete"
+
+	// Store a retained message
+	err := retainer.StoreRetained(ctx, topic, []byte("test"), 0, "client")
+	assert.NoError(t, err)
+
+	// Verify it exists
+	messages, err := retainer.GetRetainedMessages(ctx, topic)
+	assert.NoError(t, err)
+	assert.Len(t, messages, 1)
+
+	// Delete it by storing empty payload
+	err = retainer.StoreRetained(ctx, topic, []byte{}, 0, "client")
+	assert.NoError(t, err)
+
+	// Verify it's deleted
+	messages, err = retainer.GetRetainedMessages(ctx, topic)
+	assert.NoError(t, err)
+	assert.Len(t, messages, 0)
+}
+
+func TestRetainerExplicitDelete(t *testing.T) {
+	retainer := createTestRetainer(t)
+	defer retainer.Close()
+
+	ctx := context.Background()
+	topic := "test/explicit/delete"
+
+	// Store a retained message
+	err := retainer.StoreRetained(ctx, topic, []byte("test"), 0, "client")
+	assert.NoError(t, err)
+
+	// Verify it exists
+	messages, err := retainer.GetRetainedMessages(ctx, topic)
+	assert.NoError(t, err)
+	assert.Len(t, messages, 1)
+
+	// Delete explicitly
+	err = retainer.DeleteRetained(ctx, topic)
+	assert.NoError(t, err)
+
+	// Verify it's deleted
+	messages, err = retainer.GetRetainedMessages(ctx, topic)
+	assert.NoError(t, err)
+	assert.Len(t, messages, 0)
+}
+
+func TestRetainerPayloadSizeLimit(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxPayloadSize = 10 // Very small limit
+
+	backend, err := messages.NewMemoryBackend(messages.DefaultConfig())
+	require.NoError(t, err)
+
+	retainer := New(backend, config)
+	defer retainer.Close()
+
+	ctx := context.Background()
+
+	// Try to store a message that exceeds the limit
+	largePayload := make([]byte, 20)
+	err = retainer.StoreRetained(ctx, "test/large", largePayload, 0, "client")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "payload size")
+
+	// Verify it wasn't stored
+	messages, err := retainer.GetRetainedMessages(ctx, "test/large")
+	assert.NoError(t, err)
+	assert.Len(t, messages, 0)
+}
+
+func TestRetainerMessageExpiry(t *testing.T) {
+	config := DefaultConfig()
+	config.MessageExpiryInterval = 50 * time.Millisecond
+
+	backend, err := messages.NewMemoryBackend(messages.DefaultConfig())
+	require.NoError(t, err)
+
+	retainer := New(backend, config)
+	defer retainer.Close()
+
+	ctx := context.Background()
+
+	// Store a message that will expire
+	err = retainer.StoreRetained(ctx, "test/expiry", []byte("expiring"), 0, "client")
+	assert.NoError(t, err)
+
+	// Verify it exists initially
+	messages, err := retainer.GetRetainedMessages(ctx, "test/expiry")
+	assert.NoError(t, err)
+	assert.Len(t, messages, 1)
+
+	// Wait for expiry
+	time.Sleep(100 * time.Millisecond)
+
+	// Should be filtered out during retrieval
+	messages, err = retainer.GetRetainedMessages(ctx, "test/expiry")
+	assert.NoError(t, err)
+	assert.Len(t, messages, 0, "Expired message should be filtered out")
+}
+
+func TestRetainerMaxRetainedMessages(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxRetainedMessages = 2 // Very small limit
+
+	backend, err := messages.NewMemoryBackend(messages.DefaultConfig())
+	require.NoError(t, err)
+
+	retainer := New(backend, config)
+	defer retainer.Close()
+
+	ctx := context.Background()
+
+	// Store up to the limit
+	err = retainer.StoreRetained(ctx, "test/1", []byte("1"), 0, "client")
+	assert.NoError(t, err)
+
+	err = retainer.StoreRetained(ctx, "test/2", []byte("2"), 0, "client")
+	assert.NoError(t, err)
+
+	// Try to store one more (should fail)
+	err = retainer.StoreRetained(ctx, "test/3", []byte("3"), 0, "client")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum retained messages limit")
+}
+
+func TestRetainerStats(t *testing.T) {
+	retainer := createTestRetainer(t)
+	defer retainer.Close()
+
+	ctx := context.Background()
+
+	// Initial stats
+	stats := retainer.GetStats()
+	assert.Equal(t, uint64(0), stats.RetainedMessages)
+
+	// Store some messages
+	err := retainer.StoreRetained(ctx, "test/stats/1", []byte("1"), 0, "client")
+	assert.NoError(t, err)
+
+	err = retainer.StoreRetained(ctx, "test/stats/2", []byte("2"), 1, "client")
+	assert.NoError(t, err)
+
+	// Check updated stats
+	stats = retainer.GetStats()
+	assert.Equal(t, uint64(2), stats.RetainedMessages)
+	assert.Equal(t, retainer.config.MaxRetainedMessages, stats.MaxMessages)
+	assert.Equal(t, retainer.config.MaxPayloadSize, stats.MaxPayloadSize)
+}
+
+func TestRetainerCleanupRoutine(t *testing.T) {
+	config := DefaultConfig()
+	config.MessageExpiryInterval = 50 * time.Millisecond
+	config.CleanupInterval = 25 * time.Millisecond
+
+	backend, err := messages.NewMemoryBackend(messages.DefaultConfig())
+	require.NoError(t, err)
+
+	retainer := New(backend, config)
+	defer retainer.Close()
+
+	ctx := context.Background()
+
+	// Store a message that will expire
+	err = retainer.StoreRetained(ctx, "test/cleanup", []byte("expiring"), 0, "client")
+	assert.NoError(t, err)
+
+	// Verify it exists
+	stats := retainer.GetStats()
+	assert.Equal(t, uint64(1), stats.RetainedMessages)
+
+	// Wait for cleanup to run
+	time.Sleep(100 * time.Millisecond)
+
+	// Stats should show the message was cleaned up
+	// Note: This depends on the backend's implementation of cleanup
+	messages, err := retainer.GetRetainedMessages(ctx, "test/cleanup")
+	assert.NoError(t, err)
+	assert.Len(t, messages, 0, "Expired message should be cleaned up")
+}
+
+func TestMatchTopicFilter(t *testing.T) {
+	tests := []struct {
+		topic  string
+		filter string
+		match  bool
+	}{
+		{"test/topic", "test/topic", true},
+		{"test/topic", "test/other", false},
+		{"any/topic", "#", true},
+		{"test/topic", "test/+", true}, // Single-level wildcard should match
+		{"test/topic/sub", "test/+", false}, // + doesn't match multiple levels
+		{"test/topic", "+/topic", true},
+		{"foo/bar/baz", "foo/+/baz", true},
+		{"foo/bar/baz", "foo/+", false}, // + only matches one level
+		{"foo/bar", "foo/bar/#", true},
+		{"foo/bar/baz", "foo/bar/#", true},
+		{"foo", "foo/#", true},
+	}
+
+	for _, test := range tests {
+		result := MatchTopicFilter(test.topic, test.filter)
+		assert.Equal(t, test.match, result,
+			"MatchTopicFilter(%q, %q) = %v, want %v",
+			test.topic, test.filter, result, test.match)
+	}
+}
+
+func TestRetainerConcurrentAccess(t *testing.T) {
+	retainer := createTestRetainer(t)
+	defer retainer.Close()
+
+	ctx := context.Background()
+	const numGoroutines = 10
+	const messagesPerGoroutine = 10
+
+	// Concurrent writes
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			for j := 0; j < messagesPerGoroutine; j++ {
+				topic := fmt.Sprintf("concurrent/%d/%d", id, j)
+				payload := []byte(fmt.Sprintf("message-%d-%d", id, j))
+				retainer.StoreRetained(ctx, topic, payload, 0, fmt.Sprintf("client-%d", id))
+			}
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			for j := 0; j < messagesPerGoroutine; j++ {
+				topic := fmt.Sprintf("concurrent/%d/%d", id, j)
+				retainer.GetRetainedMessages(ctx, topic)
+			}
+		}(i)
+	}
+
+	// Give time for all operations to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify some messages were stored
+	messages, err := retainer.GetRetainedMessages(ctx, "#")
+	assert.NoError(t, err)
+	assert.Greater(t, len(messages), 0, "Should have stored some messages")
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -37,6 +37,8 @@ type Publish struct {
 	Payload []byte
 	// QoS is the Quality of Service level for the message.
 	QoS byte
+	// Retain indicates whether this is a retained message.
+	Retain bool
 }
 
 // Session is an actor that manages the state and network connection for a single
@@ -87,7 +89,11 @@ func (s *Session) Start(ctx context.Context, mb *actor.Mailbox) error {
 			// When a Publish message is received, create an MQTT PUBLISH packet
 			// and write it to the client's connection.
 			pk := &packets.Packet{
-				FixedHeader: packets.FixedHeader{Type: packets.Publish, Qos: m.QoS},
+				FixedHeader: packets.FixedHeader{
+					Type:   packets.Publish,
+					Qos:    m.QoS,
+					Retain: m.Retain,
+				},
 				TopicName:   m.Topic,
 				Payload:     m.Payload,
 			}

--- a/pkg/storage/messages/storage.go
+++ b/pkg/storage/messages/storage.go
@@ -319,6 +319,13 @@ func (ms *MessageStorage) GetStats() StorageStats {
 	return ms.backend.Stats()
 }
 
+// GetBackend returns the underlying storage backend
+func (ms *MessageStorage) GetBackend() StorageBackend {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return ms.backend
+}
+
 // Close shuts down the storage system
 func (ms *MessageStorage) Close() error {
 	ms.mu.Lock()

--- a/tests/e2e/retained_message_test.go
+++ b/tests/e2e/retained_message_test.go
@@ -1,0 +1,280 @@
+// Copyright 2023 The emqx-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turtacn/emqx-go/pkg/broker"
+)
+
+// TestRetainedMessageE2E tests retained message functionality end-to-end
+func TestRetainedMessageE2E(t *testing.T) {
+	t.Log("Starting Retained Message E2E test")
+
+	// Start the broker
+	b := broker.New("test-node", nil)
+	b.SetupDefaultAuth()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start broker server
+	go func() {
+		if err := b.StartServer(ctx, ":1883"); err != nil {
+			log.Printf("Test broker server failed: %v", err)
+		}
+	}()
+
+	// Give broker time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Test 1: Publish a retained message
+	t.Log("Test 1: Publishing retained message")
+
+	publisher := createMQTTClient("retained-publisher")
+	defer publisher.Disconnect(250)
+
+	token := publisher.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second), "Publisher failed to connect")
+	require.NoError(t, token.Error(), "Publisher connection error")
+
+	// Publish a retained message
+	retainedTopic := "test/retained/e2e"
+	retainedPayload := "This is a retained message for E2E testing"
+
+	pubToken := publisher.Publish(retainedTopic, 1, true, retainedPayload)
+	require.True(t, pubToken.WaitTimeout(5*time.Second), "Failed to publish retained message")
+	require.NoError(t, pubToken.Error(), "Publish error")
+
+	t.Logf("Published retained message to topic: %s", retainedTopic)
+
+	// Test 2: Subscribe and receive the retained message
+	t.Log("Test 2: Subscribing to receive retained message")
+
+	subscriber := createMQTTClient("retained-subscriber")
+	defer subscriber.Disconnect(250)
+
+	token = subscriber.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second), "Subscriber failed to connect")
+	require.NoError(t, token.Error(), "Subscriber connection error")
+
+	// Channel to receive messages
+	messageReceived := make(chan mqtt.Message, 1)
+
+	// Set up message handler
+	subscriber.Subscribe(retainedTopic, 1, func(client mqtt.Client, msg mqtt.Message) {
+		t.Logf("Received message: topic=%s, payload=%s, retained=%v",
+			msg.Topic(), string(msg.Payload()), msg.Retained())
+		messageReceived <- msg
+	})
+
+	// Wait for retained message
+	select {
+	case msg := <-messageReceived:
+		assert.Equal(t, retainedTopic, msg.Topic())
+		assert.Equal(t, retainedPayload, string(msg.Payload()))
+		assert.True(t, msg.Retained(), "Message should be marked as retained")
+		assert.Equal(t, byte(1), msg.Qos())
+		t.Log("✓ Retained message received correctly")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for retained message")
+	}
+
+	// Test 3: Update the retained message
+	t.Log("Test 3: Updating retained message")
+
+	updatedPayload := "Updated retained message content"
+	pubToken = publisher.Publish(retainedTopic, 1, true, updatedPayload)
+	require.True(t, pubToken.WaitTimeout(5*time.Second), "Failed to publish updated retained message")
+	require.NoError(t, pubToken.Error(), "Updated publish error")
+
+	// Subscribe with a new client to get the updated message
+	subscriber2 := createMQTTClient("retained-subscriber-2")
+	defer subscriber2.Disconnect(250)
+
+	token = subscriber2.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second), "Subscriber2 failed to connect")
+	require.NoError(t, token.Error(), "Subscriber2 connection error")
+
+	messageReceived2 := make(chan mqtt.Message, 1)
+	subscriber2.Subscribe(retainedTopic, 1, func(client mqtt.Client, msg mqtt.Message) {
+		messageReceived2 <- msg
+	})
+
+	// Wait for updated retained message
+	select {
+	case msg := <-messageReceived2:
+		assert.Equal(t, retainedTopic, msg.Topic())
+		assert.Equal(t, updatedPayload, string(msg.Payload()))
+		assert.True(t, msg.Retained(), "Updated message should be marked as retained")
+		t.Log("✓ Updated retained message received correctly")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for updated retained message")
+	}
+
+	// Test 4: Delete retained message (empty payload)
+	t.Log("Test 4: Deleting retained message with empty payload")
+
+	pubToken = publisher.Publish(retainedTopic, 1, true, "")
+	require.True(t, pubToken.WaitTimeout(5*time.Second), "Failed to publish delete message")
+	require.NoError(t, pubToken.Error(), "Delete publish error")
+
+	// Subscribe with a new client - should not receive any retained message
+	subscriber3 := createMQTTClient("retained-subscriber-3")
+	defer subscriber3.Disconnect(250)
+
+	token = subscriber3.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second), "Subscriber3 failed to connect")
+	require.NoError(t, token.Error(), "Subscriber3 connection error")
+
+	messageReceived3 := make(chan mqtt.Message, 1)
+	subscriber3.Subscribe(retainedTopic, 1, func(client mqtt.Client, msg mqtt.Message) {
+		if msg.Retained() {
+			messageReceived3 <- msg
+		}
+	})
+
+	// Should NOT receive any retained message
+	select {
+	case msg := <-messageReceived3:
+		t.Fatalf("Should not have received retained message after deletion, got: %s", string(msg.Payload()))
+	case <-time.After(2 * time.Second):
+		t.Log("✓ No retained message received after deletion (correct behavior)")
+	}
+
+	// Test 5: Multiple topics with retained messages
+	t.Log("Test 5: Testing multiple retained messages on different topics")
+
+	topics := []string{
+		"test/retained/topic1",
+		"test/retained/topic2",
+		"test/retained/topic3",
+	}
+
+	// Publish to multiple topics
+	for i, topic := range topics {
+		payload := fmt.Sprintf("Retained message %d", i+1)
+		pubToken = publisher.Publish(topic, 1, true, payload)
+		require.True(t, pubToken.WaitTimeout(5*time.Second), "Failed to publish to %s", topic)
+		require.NoError(t, pubToken.Error(), "Publish error for %s", topic)
+	}
+
+	// Subscribe to all topics and verify retained messages
+	subscriber4 := createMQTTClient("retained-subscriber-4")
+	defer subscriber4.Disconnect(250)
+
+	token = subscriber4.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second), "Subscriber4 failed to connect")
+	require.NoError(t, token.Error(), "Subscriber4 connection error")
+
+	receivedTopics := make(map[string]string)
+	allReceived := make(chan struct{})
+
+	subscriber4.Subscribe("test/retained/+", 1, func(client mqtt.Client, msg mqtt.Message) {
+		if msg.Retained() {
+			receivedTopics[msg.Topic()] = string(msg.Payload())
+			if len(receivedTopics) == len(topics) {
+				close(allReceived)
+			}
+		}
+	})
+
+	// Wait for all retained messages
+	select {
+	case <-allReceived:
+		for i, topic := range topics {
+			expectedPayload := fmt.Sprintf("Retained message %d", i+1)
+			actualPayload, exists := receivedTopics[topic]
+			assert.True(t, exists, "Should have received retained message for %s", topic)
+			assert.Equal(t, expectedPayload, actualPayload, "Payload mismatch for %s", topic)
+		}
+		t.Log("✓ All retained messages received correctly for multiple topics")
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timeout waiting for retained messages. Received: %v", receivedTopics)
+	}
+
+	t.Log("Retained Message E2E test completed successfully")
+}
+
+// TestRetainedMessageQoSDowngrade tests QoS downgrade behavior with retained messages
+func TestRetainedMessageQoSDowngrade(t *testing.T) {
+	t.Log("Starting Retained Message QoS Downgrade test")
+
+	// Start the broker (reuse existing broker)
+	time.Sleep(100 * time.Millisecond) // Ensure broker is ready
+
+	// Test QoS downgrade: Publish QoS 2, Subscribe QoS 1
+	publisher := createMQTTClient("qos-publisher")
+	defer publisher.Disconnect(250)
+
+	token := publisher.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+
+	// Publish retained message with QoS 2
+	topic := "test/retained/qos/downgrade"
+	payload := "QoS downgrade test message"
+
+	pubToken := publisher.Publish(topic, 2, true, payload) // QoS 2
+	require.True(t, pubToken.WaitTimeout(5*time.Second))
+	require.NoError(t, pubToken.Error())
+
+	// Subscribe with QoS 1
+	subscriber := createMQTTClient("qos-subscriber")
+	defer subscriber.Disconnect(250)
+
+	token = subscriber.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+
+	messageReceived := make(chan mqtt.Message, 1)
+	subscriber.Subscribe(topic, 1, func(client mqtt.Client, msg mqtt.Message) { // QoS 1
+		messageReceived <- msg
+	})
+
+	// Verify QoS downgrade
+	select {
+	case msg := <-messageReceived:
+		assert.Equal(t, topic, msg.Topic())
+		assert.Equal(t, payload, string(msg.Payload()))
+		assert.True(t, msg.Retained())
+		// The effective QoS should be min(publish QoS, subscription QoS) = min(2, 1) = 1
+		assert.Equal(t, byte(1), msg.Qos(), "QoS should be downgraded to subscription QoS")
+		t.Log("✓ QoS downgrade working correctly")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for QoS downgrade test message")
+	}
+
+	t.Log("Retained Message QoS Downgrade test completed successfully")
+}
+
+func createMQTTClient(clientID string) mqtt.Client {
+	opts := mqtt.NewClientOptions()
+	opts.AddBroker("tcp://localhost:1883")
+	opts.SetClientID(clientID)
+	opts.SetUsername("test")
+	opts.SetPassword("test")
+	opts.SetCleanSession(true)
+
+	return mqtt.NewClient(opts)
+}


### PR DESCRIPTION
- Add complete retainer package with storage, retrieval, expiry and cleanup
- Integrate retained message handling into broker PUBLISH/SUBSCRIBE flow
- Implement proper MQTT topic wildcard matching (+ and # wildcards)
- Add comprehensive unit tests for all retained message features
- Add end-to-end tests for complete retained message workflow
- Support message expiry, payload size limits, and message count limits
- Implement QoS level preservation and downgrade rules
- Add background cleanup of expired retained messages

Based on EMQX retainer implementation patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)